### PR TITLE
Fix missing --no-progress option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.2.2] - Jan 11, 2022
+
+### Changed
+
+* Fix missing ``--no-progress`` option for some actions
+* Fix some typos inside the help menu
+
+
 ## [4.2.1] - Jan 07, 2022
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![](https://github.com/qtc-de/remote-method-guesser/workflows/master%20maven%20CI/badge.svg?branch=master)](https://github.com/qtc-de/remote-method-guesser/actions/workflows/master.yml)
 [![](https://github.com/qtc-de/remote-method-guesser/workflows/develop%20maven%20CI/badge.svg?branch=develop)](https://github.com/qtc-de/remote-method-guesser/actions/workflows/develop.yml)
-[![](https://img.shields.io/badge/version-4.2.1-blue)](https://github.com/qtc-de/remote-method-guesser/releases)
+[![](https://img.shields.io/badge/version-4.2.2-blue)](https://github.com/qtc-de/remote-method-guesser/releases)
 [![](https://img.shields.io/badge/build%20system-maven-blue)](https://maven.apache.org/)
 ![](https://img.shields.io/badge/java-8%2b-blue)
 [![](https://img.shields.io/badge/license-GPL%20v3.0-blue)](https://github.com/qtc-de/remote-method-guesser/blob/master/LICENSE)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>remote-method-guesser</artifactId>
     <name>remote-method-guesser</name>
     <packaging>jar</packaging>
-    <version>4.2.1</version>
+    <version>4.2.2</version>
     <description>Identify common misconfigurations on Java RMI endpoints</description>
 
     <properties>

--- a/resources/bash_completion.d/rmg
+++ b/resources/bash_completion.d/rmg
@@ -226,6 +226,7 @@ function _rmg() {
             opts="$opts --guess-duplicates"
             opts="$opts --update"
             opts="$opts --zero-arg"
+            opts="$opts --no-progress"
             opts="$opts --threads"
             opts="$opts --config"
             opts="$opts --verbose"
@@ -344,6 +345,7 @@ function _rmg() {
         elif [[ $cur == -* ]] || [[ $args -ge 3 ]]; then
             opts="--help"
             opts="$opts --ports"
+            opts="$opts --no-progress"
             opts="$opts --threads"
             opts="$opts --config"
             opts="$opts --verbose"

--- a/src/de/qtc/rmg/internal/RMGOption.java
+++ b/src/de/qtc/rmg/internal/RMGOption.java
@@ -26,9 +26,9 @@ import net.sourceforge.argparse4j.inf.Namespace;
 public enum RMGOption {
 
     // Global arguments
-    GLOBAL_CONFIG("--config", "path to a configuration file", Arguments.store(), RMGOptionGroup.GENERAL, "config-file"),
+    GLOBAL_CONFIG("--config", "path to a configuration file", Arguments.store(), RMGOptionGroup.GENERAL, "path"),
     GLOBAL_VERBOSE("--verbose", "enable verbose output", Arguments.storeTrue(), RMGOptionGroup.GENERAL),
-    GLOBAL_PLUGIN("--plugin", "file system path to a rmg plugin", Arguments.store(), RMGOptionGroup.GENERAL, "plugin-file"),
+    GLOBAL_PLUGIN("--plugin", "file system path to a rmg plugin", Arguments.store(), RMGOptionGroup.GENERAL, "path"),
     GLOBAL_NO_COLOR("--no-color", "disable colored output", Arguments.storeTrue(), RMGOptionGroup.GENERAL),
     GLOBAL_STACK_TRACE("--stack-trace", "display stack traces for caught exceptions", Arguments.storeTrue(), RMGOptionGroup.GENERAL),
 
@@ -41,8 +41,8 @@ public enum RMGOption {
 
     CONN_FOLLOW("--follow", "follow redirects to different servers", Arguments.storeTrue(), RMGOptionGroup.CONNECTION),
     CONN_SSL("--ssl", "use SSL for connections", Arguments.storeTrue(), RMGOptionGroup.CONNECTION),
-    SCAN_TIMEOUT_READ("--timeout-read", "scan timeout for read operation", Arguments.store(), RMGOptionGroup.CONNECTION, "timout"),
-    SCAN_TIMEOUT_CONNECT("--timeout-connect", "scan timeout for connect operation", Arguments.store(), RMGOptionGroup.CONNECTION, "timout"),
+    SCAN_TIMEOUT_READ("--timeout-read", "scan timeout for read operation", Arguments.store(), RMGOptionGroup.CONNECTION, "sec"),
+    SCAN_TIMEOUT_CONNECT("--timeout-connect", "scan timeout for connect operation", Arguments.store(), RMGOptionGroup.CONNECTION, "sec"),
 
     SSRF_GOPHER("--gopher", "print SSRF content as gopher payload", Arguments.storeTrue(), RMGOptionGroup.SSRF),
     SSRF("--ssrf", "print SSRF payload instead of contacting a server", Arguments.storeTrue(), RMGOptionGroup.SSRF),
@@ -70,11 +70,11 @@ public enum RMGOption {
     ROGUEJMX_FORWARD_BOUND_NAME("--forward-bound-name", "bound name to forward incoming JMX connections to", Arguments.store(), RMGOptionGroup.ACTION, "name"),
     ROGUEJMX_FORWARD_OBJID("--forward-objid", "objid to forward incoming JMX connections to", Arguments.store(), RMGOptionGroup.ACTION, "objid"),
 
-    GUESS_WORDLIST_FILE("--wordlist-file", "wordlist file to use for method guessing", Arguments.store(), RMGOptionGroup.ACTION, "wordlist-file"),
-    GUESS_WORDLIST_FOLDER("--wordlist-folder", "location of the wordlist folder", Arguments.store(), RMGOptionGroup.ACTION, "wordlist-folder"),
+    GUESS_WORDLIST_FILE("--wordlist-file", "wordlist file to use for method guessing", Arguments.store(), RMGOptionGroup.ACTION, "path"),
+    GUESS_WORDLIST_FOLDER("--wordlist-folder", "location of the wordlist folder", Arguments.store(), RMGOptionGroup.ACTION, "path"),
     GUESS_CREATE_SAMPLES("--create-samples", "create sample classes for identified methods", Arguments.storeTrue(), RMGOptionGroup.ACTION),
-    GUESS_SAMPLE_FOLDER("--sample-folder", "folder used for sample generation", Arguments.store(), RMGOptionGroup.ACTION, "sample-folder"),
-    GUESS_TEMPLATE_FOLDER("--template-folder", "location of the template folder", Arguments.store(), RMGOptionGroup.ACTION, "template-folder"),
+    GUESS_SAMPLE_FOLDER("--sample-folder", "folder used for sample generation", Arguments.store(), RMGOptionGroup.ACTION, "path"),
+    GUESS_TEMPLATE_FOLDER("--template-folder", "location of the template folder", Arguments.store(), RMGOptionGroup.ACTION, "path"),
     GUESS_TRUSTED("--trusted", "disable bound name filtering", Arguments.storeTrue(), RMGOptionGroup.ACTION),
     GUESS_FORCE_GUESSING("--force-guessing", "force guessing on known remote objects", Arguments.storeTrue(), RMGOptionGroup.ACTION),
     GUESS_DUPLICATES("--guess-duplicates", "guess duplicate remote classes", Arguments.storeTrue(), RMGOptionGroup.ACTION),

--- a/src/de/qtc/rmg/operations/Operation.java
+++ b/src/de/qtc/rmg/operations/Operation.java
@@ -139,6 +139,7 @@ public enum Operation {
             RMGOption.GUESS_UPDATE,
             RMGOption.GUESS_ZERO_ARG,
             RMGOption.THREADS,
+            RMGOption.NO_PROGRESS,
     }),
 
     KNOWN("dispatchKnown", "<className>", "Display details of known remote objects", new RMGOption[] {
@@ -218,6 +219,7 @@ public enum Operation {
             RMGOption.SCAN_TIMEOUT_CONNECT,
             RMGOption.SCAN_TIMEOUT_READ,
             RMGOption.THREADS,
+            RMGOption.NO_PROGRESS,
     }),
 
     SERIAL("dispatchSerial", "<gadget> <command>", "Perform deserialization attacks against default RMI components", new RMGOption[] {

--- a/src/de/qtc/rmg/plugin/ISocketFactoryProvider.java
+++ b/src/de/qtc/rmg/plugin/ISocketFactoryProvider.java
@@ -10,33 +10,33 @@ import java.rmi.server.RMISocketFactory;
  *
  * The getClientSocketFactory function can be used to overwrite the RMIClientSocketFactory that is used for direct
  * connections (e.g. connecting to the RMI registry or an RMI endpoint directly).
- * 
+ *
  * The getDefaultSocketFactory function can be used to overwrite the RMISocketFactory that is used on RMI operations
  * that are invoked on remote objects obtained from an RMI registry.
  *
  * The getDefaultSSLSocketFactory function can be used to overwrite the RMISocketFactory that is used on RMI operations
  * that are invoked on remote objects obtained from an RMI registry, that use the default SSLSocketFactory implementation.
- * 
+ *
  * When an RMI server implements a custom RMISocketFactory on the RMI registry and for it's remote objects, you usually
  * need to do the following:
- * 
- * 		1. Add an compiled version of the server's RMISocketFactory class to your class path
- * 		2. Use the PluginSystem and the getClientSocketFactory function to make it the SocketFactory used for direct calls
- * 
+ *
+ *         1. Add an compiled version of the server's RMISocketFactory class to your class path
+ *         2. Use the PluginSystem and the getClientSocketFactory function to make it the SocketFactory used for direct calls
+ *
  * This should already be sufficient. If only remote objects use the custom RMISocketFactory, but the RMI registry is not,
  * you only need the first step. The PluginSystem is not even required in this case.
- * 
+ *
  * The getDefaultSocketFactory and getDefaultSSLSocketFactory functions are only required to modify the connection behavior
  * on default RMI connections. remote-method-guesser for example uses these functions to prevent the automatic redirection
  * that is applied by RMI when the RMI server location was set to "localhost".
- * 
+ *
  * @author Tobias Neitzel (@qtc_de)
  */
 public interface ISocketFactoryProvider {
-	
-	public RMIClientSocketFactory getClientSocketFactory(String host, int port);
-	
-	public RMISocketFactory getDefaultSocketFactory(String host, int port);
-	
-	public String getDefaultSSLSocketFactory(String host, int port);
+
+    public RMIClientSocketFactory getClientSocketFactory(String host, int port);
+
+    public RMISocketFactory getDefaultSocketFactory(String host, int port);
+
+    public String getDefaultSSLSocketFactory(String host, int port);
 }

--- a/tests/tricot.yml
+++ b/tests/tricot.yml
@@ -18,7 +18,7 @@ tester:
         ge: 1.9.0
 
 variables:
-  rmg: rmg-4.2.1-jar-with-dependencies.jar
+  rmg: rmg-4.2.2-jar-with-dependencies.jar
   volume: /tmp/rmg-tricot-test/
   volume-d: /rce/
   codebase-class: CodebaseTest


### PR DESCRIPTION
The --no-progress option was missing for the guess and scan action. This
was now added. The bash completion script was updated accordingly and
the version number was already increased to prepare a new release.