### PR TITLE
enum: returns all interface names

### DIFF
--- a/src/eu/tneitzel/rmg/utils/RMGUtils.java
+++ b/src/eu/tneitzel/rmg/utils/RMGUtils.java
@@ -1085,13 +1085,22 @@ public class RMGUtils
 
             Class<?>[] interfaces = remoteObject.getClass().getInterfaces();
 
+            StringBuilder intfNames = new StringBuilder();
+
             for(Class<?> intf : interfaces) {
 
                 String intfName = intf.getName();
 
-                if(!intfName.equals("java.rmi.Remote"))
-                    return intfName;
+                if(!intfName.equals("java.rmi.Remote")) {
+                    if(intfNames.length() != 0)
+                        intfNames.append(", ");
+
+                    intfNames.append(intfName);
+                }
             }
+
+            return intfNames.toString();
+
         }
 
         return remoteObject.getClass().getName();


### PR DESCRIPTION
This enables the _enum_ method to return more interface class names if there is more than one present. This might be a rare circumstance but was encountered.